### PR TITLE
add direct deposit address query

### DIFF
--- a/packages/indexer-client/src/IndexerBaseClient.ts
+++ b/packages/indexer-client/src/IndexerBaseClient.ts
@@ -104,8 +104,10 @@ import {
   IndexerSubaccountSnapshot,
   ListIndexerSubaccountsParams,
   ListIndexerSubaccountsResponse,
+  GetIndexerSubaccountDDAParams,
   UpdateIndexerLeaderboardRegistrationParams,
   UpdateIndexerLeaderboardRegistrationResponse,
+  GetIndexerSubaccountDDAResponse,
 } from './types';
 
 export interface IndexerClientOpts {
@@ -784,6 +786,25 @@ export class IndexerBaseClient {
 
     return {
       snapshots: baseResponse.snapshots.map(mapIndexerVlpSnapshot),
+    };
+  }
+
+  /**
+   * Retrieves the subaccount's DDA (Direct Deposit Address)
+   * @param params
+   */
+  async getSubaccountDDA(
+    params: GetIndexerSubaccountDDAParams,
+  ): Promise<GetIndexerSubaccountDDAResponse> {
+    const baseResponse = await this.query('direct_deposit_address', {
+      subaccount: subaccountToHex({
+        subaccountOwner: params.subaccountOwner,
+        subaccountName: params.subaccountName,
+      }),
+    });
+
+    return {
+      address: baseResponse.v1_address,
     };
   }
 

--- a/packages/indexer-client/src/types/clientTypes.ts
+++ b/packages/indexer-client/src/types/clientTypes.ts
@@ -677,3 +677,9 @@ export interface GetIndexerBacklogResponse {
   // Current submission rate in transactions per second (float) (null if unavailable)
   txsPerSecond: BigDecimal | null;
 }
+
+export type GetIndexerSubaccountDDAParams = Subaccount;
+
+export interface GetIndexerSubaccountDDAResponse {
+  address: string;
+}

--- a/packages/indexer-client/src/types/serverTypes.ts
+++ b/packages/indexer-client/src/types/serverTypes.ts
@@ -197,11 +197,16 @@ export interface IndexerServerVlpSnapshotsParams {
   interval: IndexerServerSnapshotsInterval;
 }
 
+export interface IndexerServerDDAQueryParams {
+  subaccount: string;
+}
+
 // Request
 export interface IndexerServerQueryRequestByType {
   account_snapshots: IndexerServerMultiSubaccountSnapshotsParams;
   backlog: Record<string, never>;
   candlesticks: IndexerServerCandlesticksParams;
+  direct_deposit_address: IndexerServerDDAQueryParams;
   edge_candlesticks: IndexerEdgeServerCandlesticksParams;
   edge_market_snapshots: IndexerEdgeServerMarketSnapshotsParams;
   events: IndexerServerEventsParams;
@@ -379,6 +384,10 @@ export interface IndexerServerVlpSnapshotsResponse {
   snapshots: IndexerServerVlpSnapshot[];
 }
 
+export interface IndexerServerDDAResponse {
+  v1_address: string;
+}
+
 export interface IndexerServerBacklogResponse {
   // Total number of transactions stored in the indexer DB
   total_txs: string;
@@ -399,6 +408,7 @@ export interface IndexerServerQueryResponseByType {
   account_snapshots: IndexerServerMultiSubaccountSnapshotsResponse;
   backlog: IndexerServerBacklogResponse;
   candlesticks: IndexerServerCandlesticksResponse;
+  direct_deposit_address: IndexerServerDDAResponse;
   edge_candlesticks: IndexerEdgeServerCandlesticksResponse;
   edge_market_snapshots: IndexerEdgeServerMarketSnapshotsResponse;
   events: IndexerServerEventsResponse;


### PR DESCRIPTION
This pull request adds support for retrieving a subaccount's Direct Deposit Address (DDA) to the indexer client. The main changes include introducing new types for DDA queries and responses, updating the client to expose a new method for fetching the DDA, and extending the server-side type definitions to support the new query.

**New API support for subaccount DDA:**

* Added new types `GetIndexerSubaccountDDAParams` and `GetIndexerSubaccountDDAResponse` to `clientTypes.ts` for specifying DDA query parameters and responses.
* Implemented the `getSubaccountDDA` method in `IndexerBaseClient` to query the direct deposit address for a subaccount.
* Updated the import statement in `IndexerBaseClient.ts` to include the new DDA types.

**Server-side type definition updates:**

* Added `IndexerServerDDAQueryParams` and `IndexerServerDDAResponse` to `serverTypes.ts` to define request and response structures for the DDA query. [[1]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R200-R209) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R387-R390)
* Extended `IndexerServerQueryRequestByType` and `IndexerServerQueryResponseByType` to include the `direct_deposit_address` query type. [[1]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R200-R209) [[2]](diffhunk://#diff-8e9ecf18a6115ef6d6d6313fb8fb9892163ec0c80260c76d4095411364bf6210R411)